### PR TITLE
Chore deprecate minting requirement

### DIFF
--- a/common-util/api/leaderboard.js
+++ b/common-util/api/leaderboard.js
@@ -10,7 +10,7 @@ export const getLeaderboardList = async () => {
   const response = await TileDocument.load(ceramic, process.env.NEXT_PUBLIC_STREAM_ID);
   const users = get(response, 'content.users') || [];
 
-  const usersList = users.filter((e) => !!e.token_id)
+  const usersList = users.filter((e) => !!e.wallet_address)
     .filter((e) => e.points !== 0)
     .map((user, index) => ({
       ...user,

--- a/components/Documentation/content/2_Actions.jsx
+++ b/components/Documentation/content/2_Actions.jsx
@@ -1,7 +1,7 @@
 import { Typography } from 'antd/lib';
 import { DOCS_SECTIONS } from '../helpers';
 
-const { Title, Paragraph, Text } = Typography;
+const { Title, Paragraph } = Typography;
 
 const ActionsDocs = () => (
   <div id={DOCS_SECTIONS.actions}>
@@ -13,50 +13,9 @@ const ActionsDocs = () => (
     </Paragraph>
 
     <Paragraph>
-      Each action has a name, instructions and points. Take a simple example:
-    </Paragraph>
-
-    <Paragraph>
-      <ul>
-        <li>
-          <Text strong>Name</Text>
-          &nbsp;– Complete an Academy Task
-        </li>
-        <li>
-          <Text strong>Instructions</Text>
-          &nbsp;– Finish one of the tasks between modules and send a screenshot
-          using the&nbsp;
-          <a
-            href="https://forms.gle/vuVNa5823CUMr4Ho6"
-            target="_blank"
-            rel="noreferrer"
-          >
-            claim form
-          </a>
-          .
-        </li>
-        <li>
-          <Text strong>Points</Text>
-          &nbsp;– 4500
-        </li>
-      </ul>
-    </Paragraph>
-
-    <Paragraph>
-      In the action in this example will earn a community member 4500 points.
-    </Paragraph>
-
-    <Paragraph>
-      Actions change regularly – new ones are added, some are removed, points
-      and instructions change etc. See the current set of actions&nbsp;
-      <a
-        href="https://discord.com/channels/899649805582737479/1030087446882418688/1034340826718937159"
-        target="_blank"
-        rel="noreferrer"
-      >
-        here
-      </a>
-      .
+      Each action has a name, instructions and points. When you complete an
+      action, it is automatically tracked and the corresponding points are added
+      to your profile.
     </Paragraph>
     <br />
     <br />

--- a/components/Documentation/content/3_Badge.jsx
+++ b/components/Documentation/content/3_Badge.jsx
@@ -9,13 +9,9 @@ const Badge = () => (
   <div id={DOCS_SECTIONS.badge}>
     <Title level={2}>Badge</Title>
     <Paragraph>
-      Community members’ points will start showing up on the leaderboard after
-      they have registered.
-    </Paragraph>
-    <Paragraph>
-      Community members can mint an Autonolas Badge. Badges are fun visual
+      Community members can mint an Contribute Badge. Badges are a fun visual
       representation of community contributions. Badges are NFTs following the
-      ERC-721 standard. Badges update when community members earn points. This
+      ERC-721 standard. They update when community members earn points. This
       happens automatically at regular intervals. The updates are done by a
       decentralized, off-chain service powered by Autonolas.
     </Paragraph>
@@ -47,7 +43,7 @@ const Badge = () => (
         <li>You should now see your badge on the website.</li>
       </ol>
     </Paragraph>
-    <Title level={5}>Badge tiers</Title>
+    <Title level={5}>Progression and tiers</Title>
     <Image
       priority
       src="/images/badge-evolution.png"


### PR DESCRIPTION
https://trello.com/c/P9Y9SSLF/1185-27-5-remove-requirement-to-mint-to-show-up-on-leaderboard

Context: to make it easier for people to quickly engage with earning points, we will remove the requirement to have minted an NFT badge in order to show up on the leaderboard.

This PR also includes 2 small updates to the docs.