### PR TITLE
Adds prediction post and retrieve

### DIFF
--- a/common-util/Education/data.json
+++ b/common-util/Education/data.json
@@ -45,5 +45,10 @@
     "id": "9dcd5c61-cc48-45e9-b393-88977f8cec17",
     "component": "proposals",
     "text": "Members can vote to approve or reject tweet proposals. Approved tweets are automatically posted by an Olas-powered service."
+  },
+  {
+    "id": "e0cf5a7e-770d-4d13-9845-7b30ee66f223",
+    "component": "predict",
+    "text": "Request predictions about the future of the DAO."
   }
 ]

--- a/common-util/api/predictionRequests.js
+++ b/common-util/api/predictionRequests.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { PREDICT_BASE_URL, PREDICT_GET_ALL_ENDPOINT } from 'util/constants';
+
+export const getPredictionRequests = async () => {
+  const response = await axios.get(PREDICT_BASE_URL + PREDICT_GET_ALL_ENDPOINT, {
+    headers: {
+      Authorization: process.env.NEXT_PUBLIC_PREDICT_API_KEY,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const markets = response.data.all_markets;
+  const prefilteredRequests = Object.keys(markets).map((key) => ({
+    ...markets[key],
+    key: markets[key].id,
+  }));
+
+  const requests = prefilteredRequests.filter(
+    (market) => market.source === 'contribute',
+  );
+
+  return requests;
+};

--- a/common-util/api/predictionRequests.js
+++ b/common-util/api/predictionRequests.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { PREDICT_BASE_URL, PREDICT_GET_ALL_ENDPOINT } from 'util/constants';
+import { PREDICT_BASE_URL, PREDICT_GET_ALL_ENDPOINT, PREDICT_REQUEST_ENDPOINT } from 'util/constants';
 
 export const getPredictionRequests = async () => {
   const response = await axios.get(PREDICT_BASE_URL + PREDICT_GET_ALL_ENDPOINT, {
@@ -20,4 +20,13 @@ export const getPredictionRequests = async () => {
   );
 
   return requests;
+};
+
+export const postPredictionRequest = async (payload) => {
+  await axios.post(PREDICT_BASE_URL + PREDICT_REQUEST_ENDPOINT, payload, {
+    headers: {
+      Authorization: process.env.NEXT_PUBLIC_PREDICT_API_KEY,
+      'Content-Type': 'application/json',
+    },
+  });
 };

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -31,10 +31,10 @@ const { useBreakpoint } = Grid;
 
 const menuItems = [
   { key: 'leaderboard', label: 'Leaderboard' },
-  // { key: 'coordinate', label: 'Coordinate' },
   { key: 'tweet', label: 'Tweet' },
   { key: 'chatbot', label: 'Chatbot' },
   { key: 'members', label: 'Members' },
+  { key: 'predict', label: 'Predict' },
   { key: 'docs', label: 'Docs' },
 ];
 

--- a/components/Predict/PredictionForm.jsx
+++ b/components/Predict/PredictionForm.jsx
@@ -43,7 +43,7 @@ const PredictionForm = () => {
       notifySuccess('Prediction requested');
     } catch (error) {
       notifyError('Request failed');
-      console.error('Error:', error);
+      console.error(error);
     } finally {
       form.resetFields();
       setIsLoading(false);

--- a/components/Predict/PredictionForm.jsx
+++ b/components/Predict/PredictionForm.jsx
@@ -2,13 +2,11 @@ import React, { useState } from 'react';
 import {
   Form, Input, Button, DatePicker,
 } from 'antd/lib';
-import axios from 'axios';
 import { uuid } from 'uuidv4';
 import { notifyError, notifySuccess } from 'common-util/functions';
 import { setPredictionRequests } from 'store/setup/actions';
-import { getPredictionRequests } from 'common-util/api/predictionRequests';
+import { getPredictionRequests, postPredictionRequest } from 'common-util/api/predictionRequests';
 import { useDispatch } from 'react-redux';
-import { PREDICT_BASE_URL, PREDICT_REQUEST_ENDPOINT } from 'util/constants';
 
 const { TextArea } = Input;
 
@@ -32,20 +30,17 @@ const PredictionForm = () => {
     };
 
     try {
-      await axios.post(PREDICT_BASE_URL + PREDICT_REQUEST_ENDPOINT, payload, {
-        headers: {
-          Authorization: process.env.NEXT_PUBLIC_PREDICT_API_KEY,
-          'Content-Type': 'application/json',
-        },
-      });
+      await postPredictionRequest(payload);
+
       const predictionRequests = await getPredictionRequests();
       dispatch(setPredictionRequests(predictionRequests));
+
       notifySuccess('Prediction requested');
+      form.resetFields();
     } catch (error) {
       notifyError('Request failed');
       console.error(error);
     } finally {
-      form.resetFields();
       setIsLoading(false);
     }
   };

--- a/components/Predict/PredictionForm.jsx
+++ b/components/Predict/PredictionForm.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {
+  Form, Input, Button, DatePicker,
+} from 'antd/lib';
+import axios from 'axios';
+import { uuid } from 'uuidv4';
+import { notifyError, notifySuccess } from 'common-util/functions';
+import { setPredictionRequests } from 'store/setup/actions';
+import { getPredictionRequests } from 'common-util/api/predictionRequests';
+import { useDispatch } from 'react-redux';
+import { PREDICT_BASE_URL, PREDICT_REQUEST_ENDPOINT } from 'util/constants';
+
+const { TextArea } = Input;
+
+const PredictionForm = () => {
+  const [form] = Form.useForm();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const dispatch = useDispatch();
+
+  const handleSubmit = async (values) => {
+    setIsLoading(true);
+
+    const payload = {
+      id: uuid(),
+      language: 'en_US',
+      source: 'contribute',
+      question: values.question,
+      resolution_time: values.resolution_time.unix(),
+      topic: 'olas',
+      answers: ['Yes', 'No'],
+    };
+
+    try {
+      await axios.post(PREDICT_BASE_URL + PREDICT_REQUEST_ENDPOINT, payload, {
+        headers: {
+          Authorization: process.env.NEXT_PUBLIC_PREDICT_API_KEY,
+          'Content-Type': 'application/json',
+        },
+      });
+      const predictionRequests = await getPredictionRequests();
+      dispatch(setPredictionRequests(predictionRequests));
+      notifySuccess('Prediction requested');
+    } catch (error) {
+      notifyError('Request failed');
+      console.error('Error:', error);
+    } finally {
+      form.resetFields();
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Form form={form} layout="vertical" onFinish={handleSubmit}>
+      <Form.Item
+        label="Question"
+        name="question"
+        extra="Questions must expect a yes/no answer"
+        rules={[{ required: true, message: 'Please input a question' }]}
+      >
+        <TextArea />
+      </Form.Item>
+
+      <Form.Item
+        label="Resolution time"
+        name="resolution_time"
+        extra="This is when you receive your answer"
+        rules={[{ required: true, message: 'Please pick the resolution time' }]}
+      >
+        <DatePicker showTime />
+      </Form.Item>
+
+      <Form.Item>
+        <Button type="primary" htmlType="submit" loading={isLoading}>
+          Request
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default PredictionForm;

--- a/components/Predict/PredictionRequestsTable.jsx
+++ b/components/Predict/PredictionRequestsTable.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { Table } from 'antd/lib';
+import dayjs from 'dayjs';
+import { getPredictionRequests } from 'common-util/api/predictionRequests';
+import { useDispatch, useSelector } from 'react-redux';
+import { setPredictionRequests } from 'store/setup/actions';
+
+const PredictionRequestsTable = () => {
+  const [loading, setLoading] = useState(true);
+
+  const dispatch = useDispatch();
+  const data = useSelector((state) => state?.setup?.predictionRequests);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const predictionRequests = await getPredictionRequests();
+        dispatch(setPredictionRequests(predictionRequests));
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const columns = [
+    {
+      title: 'Question',
+      dataIndex: 'question',
+      key: 'question',
+    },
+    {
+      title: 'Resolution Time',
+      dataIndex: 'resolution_time',
+      width: 300,
+      key: 'resolution_time',
+      // eslint-disable-next-line camelcase
+      render: (resolution_time) => dayjs.unix(resolution_time).format('HH:mm DD MMM \'YY'),
+    }, {
+      title: 'State',
+      dataIndex: 'state',
+      width: 300,
+      key: 'state',
+      render: (state) => state.charAt(0).toUpperCase() + state.slice(1).toLowerCase(),
+    },
+  ];
+
+  return <Table dataSource={data} columns={columns} loading={loading} pagination={false} />;
+};
+
+export default PredictionRequestsTable;

--- a/components/Predict/PredictionRequestsTable.jsx
+++ b/components/Predict/PredictionRequestsTable.jsx
@@ -5,6 +5,28 @@ import { getPredictionRequests } from 'common-util/api/predictionRequests';
 import { useDispatch, useSelector } from 'react-redux';
 import { setPredictionRequests } from 'store/setup/actions';
 
+const columns = [
+  {
+    title: 'Question',
+    dataIndex: 'question',
+    key: 'question',
+  },
+  {
+    title: 'Resolution Time',
+    dataIndex: 'resolution_time',
+    width: 300,
+    key: 'resolution_time',
+    // eslint-disable-next-line camelcase
+    render: (resolution_time) => dayjs.unix(resolution_time).format('HH:mm DD MMM \'YY'),
+  }, {
+    title: 'State',
+    dataIndex: 'state',
+    width: 300,
+    key: 'state',
+    render: (state) => state.charAt(0).toUpperCase() + state.slice(1).toLowerCase(),
+  },
+];
+
 const PredictionRequestsTable = () => {
   const [loading, setLoading] = useState(true);
 
@@ -26,28 +48,6 @@ const PredictionRequestsTable = () => {
 
     fetchData();
   }, []);
-
-  const columns = [
-    {
-      title: 'Question',
-      dataIndex: 'question',
-      key: 'question',
-    },
-    {
-      title: 'Resolution Time',
-      dataIndex: 'resolution_time',
-      width: 300,
-      key: 'resolution_time',
-      // eslint-disable-next-line camelcase
-      render: (resolution_time) => dayjs.unix(resolution_time).format('HH:mm DD MMM \'YY'),
-    }, {
-      title: 'State',
-      dataIndex: 'state',
-      width: 300,
-      key: 'state',
-      render: (state) => state.charAt(0).toUpperCase() + state.slice(1).toLowerCase(),
-    },
-  ];
 
   return <Table dataSource={data} columns={columns} loading={loading} pagination={false} />;
 };

--- a/components/Predict/PredictionRequestsTable.jsx
+++ b/components/Predict/PredictionRequestsTable.jsx
@@ -18,7 +18,7 @@ const PredictionRequestsTable = () => {
         const predictionRequests = await getPredictionRequests();
         dispatch(setPredictionRequests(predictionRequests));
       } catch (error) {
-        console.error('Error fetching data:', error);
+        console.error(error);
       } finally {
         setLoading(false);
       }

--- a/components/Predict/index.jsx
+++ b/components/Predict/index.jsx
@@ -1,0 +1,30 @@
+import {
+  Card, Col, Row, Typography,
+} from 'antd/lib';
+import { EducationTitle } from 'common-util/Education/EducationTitle';
+import PredictionForm from './PredictionForm';
+import PredictionRequestsTable from './PredictionRequestsTable';
+
+const { Title } = Typography;
+
+const Predict = () => (
+  <>
+    <div className="mb-24">
+      <EducationTitle title="Predict" educationItem="predict" />
+    </div>
+    <Row gutter={12}>
+      <Col lg={8} xs={24} className="mb-24">
+        <Card title={<Title level={5}>Request a prediction</Title>}>
+          <PredictionForm />
+        </Card>
+      </Col>
+      <Col lg={16} xs={24}>
+        <Card title={<Title level={5}>Requests</Title>} bodyStyle={{ padding: 0 }}>
+          <PredictionRequestsTable />
+        </Card>
+      </Col>
+    </Row>
+  </>
+);
+
+export default Predict;

--- a/pages/predict.jsx
+++ b/pages/predict.jsx
@@ -1,0 +1,3 @@
+import Predict from 'components/Predict';
+
+export default Predict;

--- a/store/setup/_types.js
+++ b/store/setup/_types.js
@@ -20,4 +20,6 @@ export const syncTypes = {
   SET_MEMORY_DETAILS_LOADING: `${reducerName}/Set memory details loading`,
 
   SET_STORE_STATE: `${reducerName}/Set Store State`,
+
+  SET_PREDICTION_REQUESTS: `${reducerName}/Set prediction reqeusts data`,
 };

--- a/store/setup/actions.js
+++ b/store/setup/actions.js
@@ -54,3 +54,8 @@ export const setLogout = () => ({
   type: syncTypes.SET_LOGOUT,
   data: null,
 });
+
+export const setPredictionRequests = (predictionRequests) => ({
+  type: syncTypes.SET_PREDICTION_REQUESTS,
+  data: { predictionRequests },
+});

--- a/store/setup/index.js
+++ b/store/setup/index.js
@@ -19,6 +19,7 @@ const initialState = {
   // memory details
   isMemoryDetailsLoading: true,
   memoryDetails: [],
+  predictionRequests: [],
 };
 
 export default (state = initialState, action) => {
@@ -38,6 +39,7 @@ export default (state = initialState, action) => {
     case syncTypes.SET_NFT_DETAILS:
     case syncTypes.SET_MEMORY_DETAILS_LOADING:
     case syncTypes.SET_MEMORY_DETAILS:
+    case syncTypes.SET_PREDICTION_REQUESTS:
     case syncTypes.SET_STORE_STATE: {
       return { ...state, ...action.data };
     }

--- a/util/constants.jsx
+++ b/util/constants.jsx
@@ -21,3 +21,7 @@ export const META_TAGS_INFO = {
 export const DEFAULT_COORDINATE_ID = '2';
 
 export const MAX_TWEET_LENGTH = 280;
+
+export const PREDICT_BASE_URL = 'http://3.16.44.108:5000';
+export const PREDICT_REQUEST_ENDPOINT = '/propose_market';
+export const PREDICT_GET_ALL_ENDPOINT = '/all_markets';

--- a/util/constants.jsx
+++ b/util/constants.jsx
@@ -22,6 +22,6 @@ export const DEFAULT_COORDINATE_ID = '2';
 
 export const MAX_TWEET_LENGTH = 280;
 
-export const PREDICT_BASE_URL = 'http://3.16.44.108:5000';
+export const PREDICT_BASE_URL = 'https://market-approval.staging.autonolas.tech';
 export const PREDICT_REQUEST_ENDPOINT = '/propose_market';
 export const PREDICT_GET_ALL_ENDPOINT = '/all_markets';


### PR DESCRIPTION
This change:
- adds the ability to request predictions from the Contribute UI
- ability to see the all previous Contribute prediction requests and their states

<img width="1920" alt="image" src="https://github.com/valory-xyz/autonolas-contribution-service-frontend/assets/66292936/1d4eeda2-a78e-4a2f-8b47-9f0f04a11c28">