### PR TITLE
Improve question-answering flow on Contribute Predict

### DIFF
--- a/components/Predict/PredictionRequestsTable.jsx
+++ b/components/Predict/PredictionRequestsTable.jsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import {
-  List, Typography, Spin, Progress, Card, Statistic,
+  List, Typography, Spin, Progress, Card, Statistic, Button,
 } from 'antd/lib';
 import dayjs from 'dayjs';
 import { getPredictionRequests } from 'common-util/api/predictionRequests';
 import { useDispatch, useSelector } from 'react-redux';
+
 import {
   setPredictionRequests,
   setApprovedRequestsCount,
 } from 'store/setup/actions';
 import { gql } from '@apollo/client';
-import { LoadingOutlined, LinkOutlined } from '@ant-design/icons';
+import { LoadingOutlined, RedoOutlined, LinkOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 import client from '../../apolloClient';
 import { ProcessingBanner } from './styles';
 
@@ -118,6 +120,20 @@ const PredictionRequestsTable = () => {
     return () => clearInterval(intervalId);
   }, []);
 
+  const router = useRouter();
+
+  const DescriptionNoTitle = () => (
+    <Text>
+      Creating prediction market...
+      You may need to
+      {' '}
+      <Button type="ghost" underline onClick={() => router.reload()}>
+        <RedoOutlined />
+        Refresh
+      </Button>
+    </Text>
+  );
+
   return (
     <>
       {approvedRequestsCount > 0 && (
@@ -188,12 +204,6 @@ const PredictionRequestsTable = () => {
                 ·
                 {' '}
                 <PredictionMarketLink fpmmId={fpmmId} />
-              </Text>
-            );
-
-            const DescriptionNoTitle = () => (
-              <Text>
-                Creating prediction market...
               </Text>
             );
 


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/9pLirLql/1295-contribute-predict-ux-enhancements-improve-question-asking-feedback-flow)

Context: when asking a question, there is a point where the market has been created, but the page doesn't automatically detect the full market. This should be relatively easy to debug, but it's cost prohibitive to test as each market uses 10xDAI. I have gone with the simplest alternative fix, which is to simply invite the user to manually refresh.

<img width="621" alt="image" src="https://github.com/valory-xyz/autonolas-contribution-service-frontend/assets/66292936/0c3cb55d-7e00-4d11-8335-a06c090a78bd">