### PR TITLE
Add cache control headers to next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,10 @@ module.exports = {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains',
           },
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=604800, stale-while-revalidate=86400',
+          },
         ],
       },
     ];


### PR DESCRIPTION
Contribute is seeing a lot of missed cache attempts via monitoring – this leads to slower performance. This change trials a new caching header policy.