### PR TITLE
fix: orbis login

### DIFF
--- a/common-util/hooks/useOrbis.jsx
+++ b/common-util/hooks/useOrbis.jsx
@@ -5,7 +5,8 @@ import {
   notifyError,
   notifySuccess,
 } from '@autonolas/frontend-library';
-import { mainnet, useAccount } from 'wagmi';
+import { useAccount } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
 
 import { RPC_URLS } from 'common-util/Contracts';
 import orbis, { ORBIS_SUPPORTED_CHAIN, checkOrbisNegativeStatus, checkOrbisStatus } from 'common-util/orbis';

--- a/components/SignInToOrbis/index.jsx
+++ b/components/SignInToOrbis/index.jsx
@@ -23,10 +23,7 @@ const SignInToOrbis = () => {
         title="Orbis enables you to use social features like Chat and Private Messages."
         delay={2000}
       >
-        <Button
-          loading={isLoading}
-          onClick={connect}
-        >
+        <Button loading={isLoading} onClick={connect}>
           Sign in to Orbis
         </Button>
       </Tooltip>
@@ -43,7 +40,7 @@ const SignInToOrbis = () => {
             Logout?
           </Menu.Item>
         </Menu>
-          )}
+      )}
       onClick={() => push(`/profile/${address}`)}
       icon={<LogoutOutlined />}
       loading={isLoading}


### PR DESCRIPTION
- The import of "chains" in Wagmi has been updated. It is now `import { mainnet } from 'wagmi/chains';` instead of `import { mainnet } from 'wagmi';`.

<img width="1512" alt="Screenshot" src="https://github.com/valory-xyz/autonolas-contribution-service-frontend/assets/22061815/fa060bcc-ad79-4e00-8ea7-80d0607cc9ba">
