### PR TITLE
chore: added meta tags top calendar and roadmap

### DIFF
--- a/common-util/meta.jsx
+++ b/common-util/meta.jsx
@@ -4,25 +4,25 @@ import Head from 'next/head';
 import { META_TAGS_INFO } from 'util/constants';
 
 const Meta = ({ meta }) => {
-  const metaInfo = meta || META_TAGS_INFO;
+  const metaInfo = {...META_TAGS_INFO, ...(meta || {})}; 
 
   return (
     <Head>
       <title>{metaInfo.title}</title>
-      <meta name="title" content={metaInfo.title} />
-      <meta name="description" content={metaInfo.description} />
+      <meta name="title" content={metaInfo.title} key="title" />
+      <meta name="description" content={metaInfo.description} key="description" />
 
-      <meta property="og:type" content="website" />
-      <meta property="og:url" content={metaInfo.siteUrl} />
-      <meta property="og:title" content={metaInfo.title} />
-      <meta property="og:description" content={metaInfo.description} />
-      <meta property="og:image" content={metaInfo.image} />
+      <meta property="og:type" content="website" key="og:type" />
+      <meta property="og:url" content={metaInfo.siteUrl} key="og:url" />
+      <meta property="og:title" content={metaInfo.title} key="og:title" />
+      <meta property="og:description" content={metaInfo.description} key="og.description" />
+      <meta property="og:image" content={metaInfo.image} key="og:image" />
 
-      <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:url" content={metaInfo.siteUrl} />
-      <meta property="twitter:title" content={metaInfo.title} />
-      <meta property="twitter:description" content={metaInfo.description} />
-      <meta property="twitter:image" content={metaInfo.image} />
+      <meta property="twitter:card" content="summary_large_image" key="twitter:card" />
+      <meta property="twitter:url" content={metaInfo.siteUrl} key="twitter:url" />
+      <meta property="twitter:title" content={metaInfo.title} key="twitter:title" />
+      <meta property="twitter:description" content={metaInfo.description} key="twitter:description" />
+      <meta property="twitter:image" content={metaInfo.image} key="twitter:image" />
     </Head>
   );
 };

--- a/components/Calendar/index.jsx
+++ b/components/Calendar/index.jsx
@@ -19,7 +19,7 @@ import { Cell } from './styles';
 const { Text, Title } = Typography;
 const { useBreakpoint } = Grid;
 
-const CalendarPage = () => {
+const CalendarComponent = () => {
   const [hidePastEvents, setHidePastEvents] = useState(true);
 
   const screens = useBreakpoint();
@@ -155,4 +155,4 @@ const CalendarPage = () => {
     </div>
   );
 };
-export default CalendarPage;
+export default CalendarComponent;

--- a/components/Roadmap/index.jsx
+++ b/components/Roadmap/index.jsx
@@ -57,7 +57,7 @@ const RoadmapLink = ({ text, link }) => {
   );
 };
 
-const RoadmapPage = () => {
+const Roadmap = () => {
   const sortedRoadmapItems = roadmapItems.sort(
     (a, b) => dayjs(b.date).unix() - dayjs(a.date).unix()
   );
@@ -133,4 +133,4 @@ const RoadmapPage = () => {
   );
 };
 
-export default RoadmapPage;
+export default Roadmap;

--- a/pages/calendar/index.jsx
+++ b/pages/calendar/index.jsx
@@ -1,3 +1,15 @@
-import CalendarPage from 'components/Calendar';
+import Meta from 'common-util/meta';
+import CalendarComponent from 'components/Calendar';
+
+const CalendarPage = () => (
+    <>
+    <Meta meta={{
+        title: 'Calendar',
+        description: 'View all the important dates and events relating to Olas Contribute.',
+        siteUrl: 'https://contribute.olas.network/calendar'
+    }} />
+    <CalendarComponent />
+    </>
+);
 
 export default CalendarPage;

--- a/pages/roadmap.jsx
+++ b/pages/roadmap.jsx
@@ -1,3 +1,15 @@
-import RoadmapPage from 'components/Roadmap';
+import Meta from 'common-util/meta';
+import Roadmap from 'components/Roadmap';
+
+const RoadmapPage = () => (
+    <>
+    <Meta meta={{
+        title: 'Roadmap',
+        description: 'Explore our Contribute roadmap to see upcoming features, milestones, and improvements.',
+        siteUrl: 'https://contribute.olas.network/roadmap'
+    }} />
+    <Roadmap />
+    </>
+)
 
 export default RoadmapPage;


### PR DESCRIPTION
## Proposed changes

Added meta tags to differentiate home from calendar and roadmap to remove duplicate title and description error from SEMrush:
![image](https://github.com/user-attachments/assets/ba07df06-577e-4cbe-ab65-5c4e8296bb6b)

## Screenshots
![image](https://github.com/user-attachments/assets/b78195ce-0600-4b6a-a0fa-2a60a8de4c7e)
![image](https://github.com/user-attachments/assets/a790a552-e6ac-4267-b8e7-3e8a1085d03d)
