### PR TITLE
feat: add evicted state and restake possibility

### DIFF
--- a/common-util/Login/LoginV2.jsx
+++ b/common-util/Login/LoginV2.jsx
@@ -102,8 +102,8 @@ export const LoginV2 = ({
           if (modalProvider?.on) {
             // https://docs.ethers.io/v5/concepts/best-practices/#best-practices--network-changes
             const handleChainChanged = () => {
-              // Temp hack not to reload page when switch to base chain on staking page
-              if (!window.location.pathname.includes('staking')) {
+              // Temp hack not to reload page when switch to base chain on staking or profile page
+              if (!['staking', 'profile'].some(segment => window.location.pathname.includes(segment))) {
                 window.location.reload();
               }
             };

--- a/common-util/functions/time.js
+++ b/common-util/functions/time.js
@@ -5,22 +5,75 @@
  */
 export const getTimeAgo = (ms, showPostfix = true) => {
   const differenceInMs = Date.now() - ms;
+  return formatTimeDifference(differenceInMs, showPostfix ? 'ago' : '')
+};
 
+export const formatTimeDifference = (differenceInMs, postfix) => {
   // Calculate time differences
   const differenceInMinutes = Math.floor(differenceInMs / (1000 * 60));
   const differenceInHours = Math.floor(differenceInMinutes / 60);
   const differenceInDays = Math.floor(differenceInHours / 24);
   const differenceInMonths = Math.floor(differenceInDays / 30); // Approximate months
 
-  const postfix = showPostfix ? ` ago` : '';
+  const postfixWithSpace = postfix ? ` ${postfix}` : '';
 
   if (differenceInMonths > 0) {
-    return `${differenceInMonths} month${differenceInMonths > 1 ? 's' : ''}${postfix}`;
+    return `${differenceInMonths} month${differenceInMonths > 1 ? 's' : ''}${postfixWithSpace}`;
   } else if (differenceInDays > 0) {
-    return `${differenceInDays} day${differenceInDays > 1 ? 's' : ''}${postfix}`;
+    return `${differenceInDays} day${differenceInDays > 1 ? 's' : ''}${postfixWithSpace}`;
   } else if (differenceInHours > 0) {
-    return `${differenceInHours} hour${differenceInHours > 1 ? 's' : ''}${postfix}`;
+    return `${differenceInHours} hour${differenceInHours > 1 ? 's' : ''}${postfixWithSpace}`;
   } else {
-    return `${differenceInMinutes} minute${differenceInMinutes > 1 ? 's' : ''}${postfix}`;
+    return `${differenceInMinutes} minute${differenceInMinutes > 1 ? 's' : ''}${postfixWithSpace}`;
   }
+}
+
+const ONE_HOUR_IN_MS = 3600 * 1000
+
+const getHourAndPeriod = (time) => {
+  let [hour, ,] = time.split(':').map(Number);
+  const period = hour >= 12 ? 'pm' : 'am';
+  hour = hour % 12 || 12; // Convert to 12-hour format, handle 0 as 12
+  return { hour, period };
 };
+
+/**
+ * 
+ * @param {*} epochEndTimestamp 
+ * @returns returns formatted time range of current hour and next hour
+ * Possible results:
+ * 8-9am, 14/11/24
+ * 11am-12pm, 14/11/24 (next time is in the next period AM to PM)
+ * 11pm-12am, 14/11/24-15/11/24 (next time is on the next day)
+ */
+export const formatDynamicTimeRange = (timestamp, timeOffsetMs = ONE_HOUR_IN_MS) => {
+  const timestampInMs = timestamp * 1000;
+
+  // Get current date and time in the format: "17/11/2024" and "13:39:07"
+  const [currentDate, currentTime] = new Date(timestampInMs)
+    .toLocaleString().split(', ');
+
+   // Get next date and time
+  const [nextDate, nextTime] = new Date(timestampInMs + timeOffsetMs)
+    .toLocaleString().split(', ');
+
+  const { hour: currentHour, period: currentPeriod } = getHourAndPeriod(currentTime);
+  const { hour: nextHour, period: nextPeriod } = getHourAndPeriod(nextTime);
+
+  let timeRange;
+  if (currentPeriod === nextPeriod && currentHour < nextHour) {
+    // makes a time range of the form "10-11am"
+    timeRange = `${currentHour}-${nextHour}${currentPeriod}`;
+  } else {
+    // makes a time range of the form "11pm-12am"
+    timeRange = `${currentHour}${currentPeriod}-${nextHour}${nextPeriod}`;
+  }
+
+  // If the dates are the same, display the time range and date
+  // otherwise, show both dates
+  if (currentDate === nextDate) {
+    return `${timeRange}, ${currentDate}`;
+  } else {
+    return `${timeRange}, ${currentDate} - ${nextDate}`;
+  }
+}

--- a/components/Profile/requests.js
+++ b/components/Profile/requests.js
@@ -1,0 +1,35 @@
+import { base } from 'wagmi/chains';
+import { waitForTransactionReceipt } from '@wagmi/core';
+import { getContributeManagerContract } from 'common-util/Contracts';
+import { getEstimatedGasLimit } from 'common-util/functions/requests';
+import { wagmiConfig } from 'common-util/Login/config';
+
+export const unstake = async ({ account }) => {
+  try {
+    const contract = getContributeManagerContract();
+    const unstakeFn = contract.methods.unstake();
+    const estimatedGas = await getEstimatedGasLimit(unstakeFn, account);
+    const result = await unstakeFn
+      .send({ from: account, gas: estimatedGas });
+    const receipt = await waitForTransactionReceipt(wagmiConfig, { chainId: base.id, hash: result.transactionHash });
+    return receipt;
+  } catch (error) {
+    console.error('Error unstaking:', error);
+    throw error
+  }
+};
+
+export const stake = async ({ account, socialId, serviceId, stakingInstance }) => {
+  try {
+    const contract = getContributeManagerContract();
+    const stakeFn = contract.methods.stake(socialId, serviceId, stakingInstance);
+    const estimatedGas = await getEstimatedGasLimit(stakeFn, account);
+    const result = await stakeFn
+      .send({ from: account, gas: estimatedGas });
+    const receipt = await waitForTransactionReceipt(wagmiConfig, { chainId: base.id, hash: result.transactionHash });
+    return receipt;
+  } catch (error) {
+    console.error('Error staking:', error);
+    throw error
+  }
+};

--- a/util/constants.js
+++ b/util/constants.js
@@ -54,3 +54,8 @@ export const STAKING_CONTRACTS_DETAILS = {
 
 export const STAKING_CONTRACTS_BASE_SUBGRAPH_URL = 'https://api.studio.thegraph.com/query/67875/olas-base-staking-rewards-history/version/latest'
 export const OLAS_UNICODE_SYMBOL = '☴';
+export const SERVICE_STAKING_STATE = [
+  'Unstaked',
+  'Staked',
+  'Evicted'
+]

--- a/util/staking.js
+++ b/util/staking.js
@@ -3,6 +3,7 @@ import { base } from 'wagmi/chains';
 import { useReadContract } from 'wagmi';
 import { useQuery } from '@tanstack/react-query';
 import { gql, request } from 'graphql-request';
+import { isNumber, isNil } from 'lodash';
 import { areAddressesEqual } from '@autonolas/frontend-library';
 import {
   CONTRIBUTORS_ABI,
@@ -10,7 +11,8 @@ import {
   STAKING_TOKEN_ABI,
 } from 'common-util/AbiAndAddresses';
 import { formatToEth } from 'common-util/functions';
-import  { STAKING_CONTRACTS_BASE_SUBGRAPH_URL } from 'util/constants';
+import { formatTimeDifference } from 'common-util/functions/time';
+import  { STAKING_CONTRACTS_BASE_SUBGRAPH_URL, SERVICE_STAKING_STATE } from 'util/constants';
 
 export const useAccountServiceInfo = (account) =>  {
   const { data, isLoading } = useReadContract({
@@ -31,14 +33,15 @@ export const useAccountServiceInfo = (account) =>  {
   return { data, isLoading };
 }
 
-export const useStakingContractConstant = (functionName, address, chainId) => (
+export const useReadStakingContract = (functionName, address, chainId, args, enabled = true) => (
   useReadContract({
     address,
     abi: STAKING_TOKEN_ABI,
     chainId,
     functionName,
+    args,
     query: {
-      enabled: !!address,
+      enabled: !!address && enabled,
     },
   })
 )
@@ -65,9 +68,15 @@ export const useStakingDetails = (serviceId, stakingInstance) =>  {
   });
 
   const { data: livenessPeriod, isLoading: isLivenessPeriodLoading } =
-    useStakingContractConstant("livenessPeriod", stakingInstance, base.id);
+    useReadStakingContract("livenessPeriod", stakingInstance, base.id);
   const { data: rewardsPerSecond, isLoading: isRewardsPerSecondLoading } =
-    useStakingContractConstant("rewardsPerSecond", stakingInstance, base.id);
+    useReadStakingContract("rewardsPerSecond", stakingInstance, base.id);
+  const { data: minStakingDuration, isLoading: isMinStakingDurationLoading } =
+    useReadStakingContract("minStakingDuration", stakingInstance, base.id);
+  const { data: stakingState, isLoading: isStakingStateLoading } =
+    useReadStakingContract("getStakingState", stakingInstance, base.id, [serviceId], !!serviceId);
+  const { data: serviceInfo, isLoading: isServiceInfoLoading } =
+    useReadStakingContract("getServiceInfo", stakingInstance, base.id, [serviceId], !!serviceId);
 
   const totalRewards = useMemo(() => {
     if (!data) return 0;
@@ -85,6 +94,7 @@ export const useStakingDetails = (serviceId, stakingInstance) =>  {
     return formatToEth(totalRewardsInWei.toString())
   }, [data, serviceId])
 
+  // Epoch's end, counter and rewards
   const epochDetails = useMemo(() => {
     if (!data) return null;
     if ((data.checkpoints || []).length === 0) return null;
@@ -100,13 +110,37 @@ export const useStakingDetails = (serviceId, stakingInstance) =>  {
     }
   }, [data, stakingInstance, livenessPeriod, rewardsPerSecond])
 
+  // Staking status: Unstaked, Staked or Evicted
+  const stakingStatus = isNumber(stakingState) ? SERVICE_STAKING_STATE[stakingState] : SERVICE_STAKING_STATE[0]
+
+  // Eviction expire timestamp
+  const evictionExpiresTimestamp = Number((serviceInfo?.tsStart ?? 0)) + Number((minStakingDuration ?? 0));
+
+  const isServiceStakedForMinimumDuration =
+    !isNil(serviceInfo?.tsStart) &&
+    !isNil(minStakingDuration) &&
+    evictionExpiresTimestamp <= Math.round(Date.now() / 1000);
+
+  // TODO: add check if the contract has enough rewards and slots
+  const isEligibleForStaking = (stakingStatus === 'Evicted' ? isServiceStakedForMinimumDuration : true);
+
   return {
     data: {
       totalRewards,
       rewardsPerEpoch: epochDetails?.rewardsPerEpoch ?? null,
       epochEndTimestamp: epochDetails?.epochEndTimestamp ?? null,
       epochCounter: epochDetails?.epochCounter ?? null,
+      epochLength: livenessPeriod ? formatTimeDifference(Number(livenessPeriod) * 1000) : null,
+      stakingStatus,
+      isEligibleForStaking,
+      evictionExpiresTimestamp,
     },
-    isLoading: isLoading || isLivenessPeriodLoading || isRewardsPerSecondLoading,
+    isLoading:
+      isLoading ||
+      isLivenessPeriodLoading ||
+      isRewardsPerSecondLoading ||
+      isMinStakingDurationLoading ||
+      isStakingStateLoading ||
+      isServiceInfoLoading,
   };
 }


### PR DESCRIPTION
1) Moves columns as per updated design
2) Adds epoch length column
3) Changes olas staked to staking status - can be not staked, staked * staked OLAS or evicted
4) if evicted:
 - if can restake, displays relevant button which calls unstake and then stake to the same contract
 - if can't restake due to being staked not enough time (used the logic from Pearl app) - the button is disabled and the message is shown saying when a user can restake
5) if evicted or unstaked, the current num of tweets made this epoch is alway 0

### Evicted state
<img width="274" alt="Screenshot 2024-11-15 at 18 40 53" src="https://github.com/user-attachments/assets/c4e9d9f2-45bf-4440-8627-dceb8a3930a6">

### Evicted state tooltip
<img width="492" alt="Screenshot 2024-11-15 at 18 41 07" src="https://github.com/user-attachments/assets/f4450110-22e0-4964-b019-882250cea15e">

### Restake disabled message
<img width="320" alt="Screenshot 2024-11-15 at 18 40 58" src="https://github.com/user-attachments/assets/6b11acf9-667f-4a92-a919-52e39da4d715">


