### PR TITLE
feat: tweet evaluation update

### DIFF
--- a/common-util/prop-types.js
+++ b/common-util/prop-types.js
@@ -94,3 +94,10 @@ export const CentaurPropTypes = PropTypes.shape({
     memberWhitelist: PropTypes.arrayOf(PropTypes.string),
   }),
 });
+
+export const TweetShape = {
+  epoch: PropTypes.number,
+  points: PropTypes.number.isRequired,
+  campaign: PropTypes.string,
+  timestamp: PropTypes.string,
+};

--- a/components/Leaderboard/Campaigns/index.jsx
+++ b/components/Leaderboard/Campaigns/index.jsx
@@ -39,8 +39,8 @@ export const Campaigns = () => {
         <a href="https://twitter.com/autonolas" target="_blank" rel="noopener noreferrer">
           @autonolas
         </a>{' '}
-        and include at least one of the following tags to earn leaderboard points and be eligible
-        for staking rewards.
+        or use at least one of the following tags in your tweet to earn leaderboard points and be
+        eligible for staking rewards.
       </Paragraph>
       <Paragraph>
         The leaderboard points you can earn by tweeting vary according to the AI&apos;s evaluation.

--- a/components/Profile/PointsShowcase.jsx
+++ b/components/Profile/PointsShowcase.jsx
@@ -21,41 +21,46 @@ const NoTweetsText = styled(Paragraph)`
   max-width: 400px;
 `;
 
-export const PointsShowcase = memo(({ tweetsData }) => {
-  const earnedPointsTweets = Object.entries(tweetsData || {})
-    .map(([tweetId, tweet]) => ({ tweetId, points: tweet.points }))
-    .filter(({ points }) => points > 0);
+export const PointsShowcase = memo(
+  ({ tweetsData }) => {
+    const earnedPointsTweets = Object.entries(tweetsData || {})
+      .map(([tweetId, tweet]) => ({ tweetId, points: tweet.points }))
+      .filter(({ points }) => points > 0);
 
-  const tweets = shuffleArray(earnedPointsTweets).slice(0, MAX_TWEETS_SHOWN);
+    const tweets = shuffleArray(earnedPointsTweets).slice(0, MAX_TWEETS_SHOWN);
 
-  return (
-    <>
-      <Text className="font-weight-600 mt-24" type="secondary">
-        Points Showcase
-      </Text>
-      {tweets.length > 0 ? (
-        <>
-          <Paragraph type="secondary">
-            Here is a selection of tweets you have made that have earned points.
-          </Paragraph>
+    return (
+      <>
+        <Text className="font-weight-600 mt-24" type="secondary">
+          Points Showcase
+        </Text>
+        {tweets.length > 0 ? (
+          <>
+            <Paragraph type="secondary">
+              Here is a selection of tweets you have made that have earned points.
+            </Paragraph>
 
-          <Row gutter={[16, 16]} className="mt-12">
-            {tweets.map((item) => (
-              <StyledCol key={item.tweetId} xs={24} md={8}>
-                <TweetEmbed tweetId={item.tweetId} points={item.points} width={250} />
-              </StyledCol>
-            ))}
-          </Row>
-        </>
-      ) : (
-        <NoTweetsText type="secondary" className="mt-12">
-          No tweets found. Connect your Twitter account and start completing{' '}
-          <Link href="/leaderboard">actions</Link> to earn more points
-        </NoTweetsText>
-      )}
-    </>
-  );
-});
+            <Row gutter={[16, 16]} className="mt-12">
+              {tweets.map((item) => (
+                <StyledCol key={item.tweetId} xs={24} md={8}>
+                  <TweetEmbed tweetId={item.tweetId} points={item.points} width={250} />
+                </StyledCol>
+              ))}
+            </Row>
+          </>
+        ) : (
+          <NoTweetsText type="secondary" className="mt-12">
+            No tweets found. Connect your Twitter account and start completing{' '}
+            <Link href="/leaderboard">actions</Link> to earn more points
+          </NoTweetsText>
+        )}
+      </>
+    );
+  },
+  (prevProps, nextProps) => {
+    return JSON.stringify(prevProps.tweetsData) === JSON.stringify(nextProps.tweetsData);
+  },
+);
 
 PointsShowcase.displayName = 'PointsShowcase';
 PointsShowcase.propTypes = {

--- a/components/Profile/PointsShowcase.jsx
+++ b/components/Profile/PointsShowcase.jsx
@@ -1,151 +1,32 @@
-import { Card, Col, Row, Spin, Typography } from 'antd';
+import { Col, Row, Typography } from 'antd';
 import Link from 'next/link';
-import Script from 'next/script';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo } from 'react';
 import styled from 'styled-components';
 
+import { TweetShape } from 'common-util/prop-types';
+
+import { TweetEmbed } from './TweetEmbed';
 import { shuffleArray } from './utils';
 
 const MAX_TWEETS_SHOWN = 2;
 
 const { Paragraph, Text } = Typography;
 
-const TweetLoader = styled.div`
-  display: flex;
-  justify-content: center;
-  margin: 16px;
-`;
-
 const StyledCol = styled(Col)`
   flex: auto;
   max-width: 306px;
 `;
-
-const StyledCard = styled(Card)`
-  max-width: 282px;
-  width: 100%;
-`;
-
 const NoTweetsText = styled(Paragraph)`
   max-width: 400px;
 `;
 
-const TweetEmbed = ({ points, tweetId, isScriptReady, isError, onError }) => {
-  const isLoaded = useRef(false);
-  const [isLoading, setIsLoading] = useState(true);
+export const PointsShowcase = memo(({ tweetsData }) => {
+  const earnedPointsTweets = Object.entries(tweetsData || {})
+    .map(([tweetId, tweet]) => ({ tweetId, points: tweet.points }))
+    .filter(({ points }) => points > 0);
 
-  const createTweet = useCallback(() => {
-    try {
-      if (isLoaded.current) return;
-
-      const element = document.getElementById(`tweet-container-${tweetId}`);
-      if (!element) return;
-
-      window.twttr.widgets.createTweet(tweetId, element, {
-        width: 250,
-        cards: 'hidden',
-        conversation: 'none',
-      });
-      isLoaded.current = true;
-    } catch {
-      onError();
-    }
-  }, [onError, tweetId]);
-
-  useEffect(() => {
-    // Observe changes inside the tweet node,
-    // to update loading state in case of success or errors
-    const element = document.getElementById(`tweet-container-${tweetId}`);
-
-    // Observer for changes in styles of the iframe
-    const iframeObserver = new MutationObserver((mutationsList) => {
-      mutationsList.forEach((mutation) => {
-        if (mutation.target.style.cssText.includes('visibility: visible')) {
-          setIsLoading(false);
-          iframeObserver.disconnect();
-        }
-      });
-    });
-
-    // Observer for changes in the first child node
-    const tweetContainerObserver = new MutationObserver((mutationsList) => {
-      mutationsList.forEach((mutation) => {
-        const tweetContainer = mutation.target.childNodes[0];
-        if (tweetContainer && tweetContainer.className.includes('rendered')) {
-          // It takes some time to display tweet, iframe in that case gets new styles -
-          // we should start tracking iframe instead, to display more accurate loading state
-          iframeObserver.observe(tweetContainer.querySelector('iframe'), {
-            attributes: true,
-            attributeFilter: ['style'],
-          });
-
-          // Stop observing once content is added
-          tweetContainerObserver.disconnect();
-        }
-      });
-    });
-
-    // Start observing changes in the first child node
-    tweetContainerObserver.observe(element, {
-      childList: true,
-    });
-
-    return () => {
-      tweetContainerObserver.disconnect();
-      iframeObserver.disconnect();
-    };
-  }, [tweetId]);
-
-  useEffect(() => {
-    if (isScriptReady) {
-      createTweet();
-    }
-  }, [createTweet, isScriptReady]);
-
-  return (
-    <StyledCard
-      title={`Points earned: ${points}`}
-      styles={{ title: { fontSize: '16px' }, body: { padding: '8px 16px' } }}
-    >
-      <div id={`tweet-container-${tweetId}`} />
-      {isLoading && (
-        <TweetLoader>
-          <Spin size="large" />
-        </TweetLoader>
-      )}
-      {isError && <TweetLoader>Error loading tweet</TweetLoader>}
-    </StyledCard>
-  );
-};
-
-TweetEmbed.propTypes = {
-  tweetId: PropTypes.string.isRequired,
-  points: PropTypes.number.isRequired,
-  isScriptReady: PropTypes.bool.isRequired,
-  isError: PropTypes.bool.isRequired,
-  onError: PropTypes.func.isRequired,
-};
-
-export const PointsShowcase = ({ tweetsData }) => {
-  const [isScriptReady, setIsScriptReady] = useState(false);
-  const [isError, setIsError] = useState(false);
-
-  const onError = () => {
-    setIsError(true);
-  };
-
-  const onReady = () => {
-    setIsScriptReady(true);
-  };
-
-  const tweets = useMemo(() => {
-    const earnedPointsTweets = Object.entries(tweetsData || {})
-      .map(([tweetId, tweet]) => ({ tweetId, points: tweet.points }))
-      .filter(({ points }) => points > 0);
-
-    return shuffleArray(earnedPointsTweets).slice(0, MAX_TWEETS_SHOWN);
-  }, [tweetsData]);
+  const tweets = shuffleArray(earnedPointsTweets).slice(0, MAX_TWEETS_SHOWN);
 
   return (
     <>
@@ -158,23 +39,10 @@ export const PointsShowcase = ({ tweetsData }) => {
             Here is a selection of tweets you have made that have earned points.
           </Paragraph>
 
-          <Script
-            id="twitter-widgets"
-            src="https://platform.twitter.com/widgets.js"
-            onReady={onReady}
-            onError={onError}
-          />
-
           <Row gutter={[16, 16]} className="mt-12">
             {tweets.map((item) => (
               <StyledCol key={item.tweetId} xs={24} md={8}>
-                <TweetEmbed
-                  tweetId={item.tweetId}
-                  points={item.points}
-                  isScriptReady={isScriptReady}
-                  isError={isError}
-                  onError={onError}
-                />
+                <TweetEmbed tweetId={item.tweetId} points={item.points} width={250} />
               </StyledCol>
             ))}
           </Row>
@@ -187,15 +55,9 @@ export const PointsShowcase = ({ tweetsData }) => {
       )}
     </>
   );
-};
+});
 
-const TweetShape = {
-  epoch: PropTypes.number,
-  points: PropTypes.number.isRequired,
-  campaign: PropTypes.string,
-  timestamp: PropTypes.string,
-};
-
+PointsShowcase.displayName = 'PointsShowcase';
 PointsShowcase.propTypes = {
   tweetsData: PropTypes.objectOf(PropTypes.shape(TweetShape)).isRequired,
 };

--- a/components/Profile/PointsShowcase.jsx
+++ b/components/Profile/PointsShowcase.jsx
@@ -1,4 +1,5 @@
 import { Col, Row, Typography } from 'antd';
+import isEqual from 'lodash/isEqual';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { memo } from 'react';
@@ -57,9 +58,7 @@ export const PointsShowcase = memo(
       </>
     );
   },
-  (prevProps, nextProps) => {
-    return JSON.stringify(prevProps.tweetsData) === JSON.stringify(nextProps.tweetsData);
-  },
+  (prevProps, nextProps) => isEqual(prevProps.tweetsData, nextProps.tweetsData),
 );
 
 PointsShowcase.displayName = 'PointsShowcase';

--- a/components/Profile/Staking.jsx
+++ b/components/Profile/Staking.jsx
@@ -198,14 +198,13 @@ const StakingDetails = ({ profile }) => {
   const tweetsThisEpoch = useMemo(() => {
     if (!isNumber(stakingDetails.epochCounter)) return [];
     if (stakingDetails.stakingStatus !== 'Staked') return [];
-    // Calculate total points earned for current epoch's tweets
     return Object.entries(profile.tweets)
       .map(([tweetId, tweet]) => ({ tweetId, ...tweet }))
       .filter((tweet) => tweet.epoch > stakingDetails.epochCounter && tweet.points > 0);
   }, [profile, stakingDetails]);
 
+  // Calculate total points earned for current epoch's tweets
   const pointsEarned = useMemo(() => {
-    // Calculate total points earned for current epoch's tweets
     return tweetsThisEpoch.reduce((sum, tweet) => {
       if (tweet.epoch > stakingDetails.epochCounter) {
         sum += tweet.points;

--- a/components/Profile/TweetEmbed.jsx
+++ b/components/Profile/TweetEmbed.jsx
@@ -1,0 +1,83 @@
+import { ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Spin, Typography } from 'antd';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { TwitterTweetEmbed } from 'react-twitter-embed';
+import styled from 'styled-components';
+
+const { Text } = Typography;
+
+const TweetPlaceholder = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  margin: 16px;
+  min-height: 120px;
+`;
+
+const StyledCard = styled(Card)`
+  width: 100%;
+`;
+
+export const TweetEmbed = ({ points, tweetId, width = 250 }) => {
+  const [isError, setIsError] = useState(false);
+  const [isMounted, setIsMounted] = useState(true);
+
+  const handleReload = () => {
+    // Toggle isMounted state so that TwitterTweetEmbed
+    // component is mounted again nad can be reloaded
+    setIsMounted(false);
+    setTimeout(() => setIsMounted(true));
+    setIsError(false);
+  };
+
+  return (
+    <StyledCard
+      title={`Points earned: ${points}`}
+      style={{ maxWidth: `${width + 32}px` }}
+      styles={{
+        title: { fontSize: '16px' },
+        body: { padding: '8px 16px' },
+      }}
+    >
+      {isError && (
+        <TweetPlaceholder>
+          <Text className="block">Error loading tweet</Text>
+          <Button onClick={handleReload} icon={<ReloadOutlined />} type="text" />
+        </TweetPlaceholder>
+      )}
+      {isMounted && (
+        <TwitterTweetEmbed
+          tweetId={`${tweetId}`}
+          options={{
+            width,
+            cards: 'hidden',
+            conversation: 'none',
+          }}
+          onLoad={(element) => {
+            if (!element) {
+              setIsError(true);
+            }
+          }}
+          placeholder={
+            <TweetPlaceholder>
+              <Spin size="large" />
+            </TweetPlaceholder>
+          }
+        />
+      )}
+    </StyledCard>
+  );
+};
+
+TweetEmbed.propTypes = {
+  tweetId: PropTypes.string.isRequired,
+  points: PropTypes.number.isRequired,
+  width: PropTypes.number,
+};
+
+TweetEmbed.defaultValues = {
+  width: 250,
+};

--- a/components/Profile/TweetEmbed.jsx
+++ b/components/Profile/TweetEmbed.jsx
@@ -13,6 +13,7 @@ const TweetPlaceholder = styled.div`
   gap: 8px;
   align-items: center;
   justify-content: center;
+  text-align: center;
   margin: 16px;
   min-height: 120px;
 `;
@@ -23,13 +24,13 @@ const StyledCard = styled(Card)`
 
 export const TweetEmbed = ({ points, tweetId, width = 250 }) => {
   const [isError, setIsError] = useState(false);
-  const [isMounted, setIsMounted] = useState(true);
+  const [isReloading, setIsReloading] = useState(false);
 
+  // Toggle isReloading state so that TwitterTweetEmbed
+  // component is mounted again and can be reloaded automatically
   const handleReload = () => {
-    // Toggle isMounted state so that TwitterTweetEmbed
-    // component is mounted again nad can be reloaded
-    setIsMounted(false);
-    setTimeout(() => setIsMounted(true));
+    setIsReloading(true);
+    setTimeout(() => setIsReloading(false));
     setIsError(false);
   };
 
@@ -44,11 +45,11 @@ export const TweetEmbed = ({ points, tweetId, width = 250 }) => {
     >
       {isError && (
         <TweetPlaceholder>
-          <Text className="block">Error loading tweet</Text>
+          <Text className="block">Failed to load the tweet, please try reloading</Text>
           <Button onClick={handleReload} icon={<ReloadOutlined />} type="text" />
         </TweetPlaceholder>
       )}
-      {isMounted && (
+      {!isReloading && (
         <TwitterTweetEmbed
           tweetId={`${tweetId}`}
           options={{

--- a/components/Profile/TweetsThisEpoch.jsx
+++ b/components/Profile/TweetsThisEpoch.jsx
@@ -41,7 +41,7 @@ export const TweetsThisEpoch = ({ tweets }) => {
   ) : (
     <Flex vertical align="center" className="mt-24 mb-24">
       <TwitterOutlined style={{ color: '#A3AEBB', fontSize: 48 }} />
-      <Text type="secondary">No tweets this epoch yet.</Text>
+      <Text type="secondary">No tweets posted this epoch yet.</Text>
       <Text type="secondary">Share something on Twitter!</Text>
     </Flex>
   );

--- a/components/Profile/TweetsThisEpoch.jsx
+++ b/components/Profile/TweetsThisEpoch.jsx
@@ -1,0 +1,54 @@
+import { TwitterOutlined } from '@ant-design/icons';
+import { Col, Flex, Grid, Row, Typography } from 'antd';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { TweetShape } from 'common-util/prop-types';
+
+import { TweetEmbed } from './TweetEmbed';
+
+const { Text } = Typography;
+const { useBreakpoint } = Grid;
+
+const Scrollable = styled.div`
+  max-height: 350px;
+  overflow: auto;
+`;
+
+const MOBILE_TWEET_WIDTH = 250;
+const TWEET_WIDTH = 310;
+
+export const TweetsThisEpoch = ({ tweets }) => {
+  const screens = useBreakpoint();
+  const isMobile = !!screens.xs;
+
+  const tweetWidth = isMobile ? MOBILE_TWEET_WIDTH : TWEET_WIDTH;
+  return tweets.length > 0 ? (
+    <Scrollable>
+      <Row gutter={[16, 16]} className="mt-12">
+        {tweets.map((item) => (
+          <Col
+            key={item.tweetId}
+            xs={24}
+            md={12}
+            style={{ width: '100%', maxWidth: `${tweetWidth + 50}px` }}
+          >
+            <TweetEmbed tweetId={item.tweetId} points={item.points} width={tweetWidth} />
+          </Col>
+        ))}
+      </Row>
+    </Scrollable>
+  ) : (
+    <Flex vertical align="center" className="mt-24 mb-24">
+      <TwitterOutlined style={{ color: '#A3AEBB', fontSize: 48 }} />
+      <Text type="secondary">No tweets this epoch yet.</Text>
+      <Text type="secondary">Share something on Twitter!</Text>
+    </Flex>
+  );
+};
+
+TweetsThisEpoch.propTypes = {
+  tweets: PropTypes.arrayOf(
+    PropTypes.shape({ ...TweetShape, tweetId: PropTypes.string.isRequired }),
+  ).isRequired,
+};

--- a/components/Profile/index.jsx
+++ b/components/Profile/index.jsx
@@ -11,6 +11,7 @@ import { BadgeLoading, ShowBadge } from 'common-util/ShowBadge';
 import TruncatedEthereumLink from 'common-util/TruncatedEthereumLink';
 import { getLatestMintedNft } from 'common-util/api';
 import { getName, getTier } from 'common-util/functions';
+import { TweetShape } from 'common-util/prop-types';
 
 import ConnectTwitterModal from '../ConnectTwitter/Modal';
 import { PointsShowcase } from './PointsShowcase';
@@ -151,13 +152,6 @@ const ProfileBody = ({ profile, id }) => {
       {account && areAddressesEqual(id, account) && <Staking profile={profile} />}
     </Root>
   );
-};
-
-const TweetShape = {
-  epoch: PropTypes.number,
-  points: PropTypes.number.isRequired,
-  campaign: PropTypes.string,
-  timestamp: PropTypes.string,
 };
 
 ProfileBody.propTypes = {

--- a/components/Staking/StakingStepper.jsx
+++ b/components/Staking/StakingStepper.jsx
@@ -206,8 +206,8 @@ const SetUpAndStake = ({ disabled, twitterId, multisigAddress, onNextStep }) => 
                   <Text className="font-weight-600">{item.name}</Text>
                   <Text type="secondary">
                     {` | ${item.totalBond} OLAS stake | ${
-                      item.tweetsPerEpoch
-                    } tweet${item.tweetsPerEpoch > 1 ? 's' : ''} per epoch`}
+                      item.pointsPerEpoch
+                    } point${item.pointsPerEpoch > 1 ? 's' : ''} per epoch`}
                   </Text>
                 </Radio>
               ))}
@@ -242,6 +242,10 @@ const TweetAndEarn = ({ disabled }) => {
       <Paragraph type="secondary">
         Visit your user profile page and participate in tweet campaigns. If you post enough for the
         epoch, you might be eligible to earn staking rewards.
+      </Paragraph>
+      <Paragraph type="secondary">
+        First epoch activity reward is proportional to the time between contributor registration and
+        the end of the on-going epoch
       </Paragraph>
       <Link href={`/profile/${address}`} passHref>
         <Button type="primary" disabled={disabled}>

--- a/components/Staking/StakingStepper.jsx
+++ b/components/Staking/StakingStepper.jsx
@@ -245,7 +245,7 @@ const TweetAndEarn = ({ disabled }) => {
       </Paragraph>
       <Paragraph type="secondary">
         First epoch activity reward is proportional to the time between contributor registration and
-        the end of the on-going epoch
+        the end of the on-going epoch.
       </Paragraph>
       <Link href={`/profile/${address}`} passHref>
         <Button type="primary" disabled={disabled}>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-moment": "^1.1.3",
     "react-redux": "^9.0.4",
     "react-syntax-highlighter": "^15.5.0",
+    "react-twitter-embed": "^4.0.4",
     "remark-gfm": "^3.0.1",
     "styled-components": "^6.0.7",
     "uint8arrays": "3.1.1",

--- a/util/constants.js
+++ b/util/constants.js
@@ -38,17 +38,17 @@ export const STAKING_CONTRACTS_DETAILS = {
   '0x00000000000000000000000095146adf659f455f300d7521b3b62a3b6c4aba1f': {
     name: 'Contribute Alpha',
     totalBond: 100,
-    tweetsPerEpoch: 1,
+    pointsPerEpoch: 200,
   },
   '0x0000000000000000000000002c8a5ac7b431ce04a037747519ba475884bce2fb': {
     name: 'Contribute Alpha 2',
     totalBond: 100,
-    tweetsPerEpoch: 1,
+    pointsPerEpoch: 200,
   },
   '0x000000000000000000000000708e511d5fcb3bd5a5d42f42aa9a69ec5b0ee2e8': {
     name: 'Contribute Alpha 3',
     totalBond: 500,
-    tweetsPerEpoch: 5,
+    pointsPerEpoch: 1000,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13863,6 +13863,13 @@ react-syntax-highlighter@^15.5.0:
     prismjs "^1.27.0"
     refractor "^3.6.0"
 
+react-twitter-embed@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-twitter-embed/-/react-twitter-embed-4.0.4.tgz#4a6b8354acc266876ff1110b9f648518ea20db6d"
+  integrity sha512-2JIL7qF+U62zRzpsh6SZDXNI3hRNVYf5vOZ1WRcMvwKouw+xC00PuFaD0aEp2wlyGaZ+f4x2VvX+uDadFQ3HVA==
+  dependencies:
+    scriptjs "^2.5.9"
+
 react@>=17, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -14349,6 +14356,11 @@ schema-utils@^4.0.0:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+scriptjs@^2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
+  integrity sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==
 
 scroll-into-view-if-needed@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
1) replaced previous manual embed tweet implementation with the most recent and suitable library from here https://developer.x.com/en/docs/x-for-websites/tools-and-libraries; now it's easily handled with less code, and doesn't jump too much while loading
2) added reload functionality so that if a tweet wasn't loaded it can be reloaded
3) switched from the number of tweets to the number of points for staking contracts
4) displayed tweets made this epoch

### Desktop view

https://github.com/user-attachments/assets/dfde617a-16ce-430b-9593-993a8db0bf73

### Mobile view (the embedded tweet's minimum width is 250px, so placing it inside a card and then the card inside a Collapse causes it not to fit.)

https://github.com/user-attachments/assets/21b17ebe-7618-4b59-9e49-e9a336c3dcb7

### Rewards earned state
<img width="896" alt="Screenshot 2024-11-20 at 22 25 55" src="https://github.com/user-attachments/assets/e2b0bcb7-afaa-440e-859b-40a7bacf6b57">

### Empty tweets list state
<img width="906" alt="Screenshot 2024-11-20 at 22 35 58" src="https://github.com/user-attachments/assets/f48dc745-4183-410c-a321-1a0041eb628d">


