### PR TITLE
Feat/cleanup

### DIFF
--- a/common-util/AbiAndAddresses/serviceRegistryL2.ts
+++ b/common-util/AbiAndAddresses/serviceRegistryL2.ts
@@ -1889,4 +1889,4 @@ export const SERVICE_REGISTRY_L2_ABI = [
     stateMutability: 'nonpayable',
     type: 'function',
   },
-];
+] as const;

--- a/common-util/api/leaderboard.js
+++ b/common-util/api/leaderboard.js
@@ -50,3 +50,28 @@ export const updateUserStakingData = async (twitterId, multisig, serviceId) => {
   // Update the data
   await response.update(newContent);
 };
+
+export const clearUserOldStakingData = async (twitterId) => {
+  const provider = new Ed25519Provider(fromString(process.env.NEXT_PUBLIC_CERAMIC_SEED, 'base16'));
+  const did = new DID({ provider, resolver: getResolver() });
+  // Authenticate the DID with the provider
+  await did.authenticate();
+  // The Ceramic client can create and update streams using the authenticated DID
+  CERAMIC_OBJECT.did = did;
+
+  const response = await TileDocument.load(CERAMIC_OBJECT, process.env.NEXT_PUBLIC_STREAM_ID);
+
+  const newContent = cloneDeep(response.content);
+
+  // Find a user by the provided twitterId
+  for (let key in newContent.users) {
+    if (newContent.users[key].twitter_id === twitterId) {
+      newContent.users[key].service_multisig_old = null;
+      newContent.users[key].service_id_old = null;
+      break;
+    }
+  }
+
+  // Update the data
+  await response.update(newContent);
+};

--- a/common-util/functions/requests.js
+++ b/common-util/functions/requests.js
@@ -1,4 +1,5 @@
-const ESTIMATED_GAS_LIMIT = 500_000;
+// TODO: better handle setting 2M for base/gnosis, 500k for ethereum
+const ESTIMATED_GAS_LIMIT = 2_000_000;
 
 /**
  * function to estimate gas limit

--- a/common-util/functions/time.ts
+++ b/common-util/functions/time.ts
@@ -8,7 +8,7 @@ export const getTimeAgo = (ms: number, showPostfix = true) => {
   return formatTimeDifference(differenceInMs, showPostfix ? 'ago' : '');
 };
 
-export const formatTimeDifference = (differenceInMs: number, postfix: string) => {
+export const formatTimeDifference = (differenceInMs: number, postfix?: string) => {
   // Calculate time differences
   const differenceInMinutes = Math.floor(differenceInMs / (1000 * 60));
   const differenceInHours = Math.floor(differenceInMinutes / 60);

--- a/common-util/functions/time.ts
+++ b/common-util/functions/time.ts
@@ -3,12 +3,12 @@
  * @param ms timestamp in ms
  * @returns time in format "12 days ago" or "5 hours ago"
  */
-export const getTimeAgo = (ms, showPostfix = true) => {
+export const getTimeAgo = (ms: number, showPostfix = true) => {
   const differenceInMs = Date.now() - ms;
   return formatTimeDifference(differenceInMs, showPostfix ? 'ago' : '');
 };
 
-export const formatTimeDifference = (differenceInMs, postfix) => {
+export const formatTimeDifference = (differenceInMs: number, postfix: string) => {
   // Calculate time differences
   const differenceInMinutes = Math.floor(differenceInMs / (1000 * 60));
   const differenceInHours = Math.floor(differenceInMinutes / 60);
@@ -31,7 +31,7 @@ export const formatTimeDifference = (differenceInMs, postfix) => {
 const ONE_HOUR_IN_MS = 3600 * 1000;
 
 // Considering provided time format is en-US
-const getHourAndPeriod = (time) => {
+const getHourAndPeriod = (time: string) => {
   let [hour, ,] = time.split(':').map(Number);
   const period = time.includes('PM') ? 'pm' : 'am';
   return { hour, period };
@@ -46,7 +46,7 @@ const getHourAndPeriod = (time) => {
  * 11am-12pm, 14/11/24 (next time is in the next period AM to PM)
  * 11pm-12am, 14/11/24-15/11/24 (next time is on the next day)
  */
-export const formatDynamicTimeRange = (timestamp, timeOffsetMs = ONE_HOUR_IN_MS) => {
+export const formatDynamicTimeRange = (timestamp: number, timeOffsetMs = ONE_HOUR_IN_MS) => {
   const timestampInMs = timestamp * 1000;
 
   // Get current date and time in the format: "17/11/2024" and "13:39:07"
@@ -76,4 +76,19 @@ export const formatDynamicTimeRange = (timestamp, timeOffsetMs = ONE_HOUR_IN_MS)
   } else {
     return `${timeRange}, ${currentDate} - ${nextDate}`;
   }
+};
+
+/**
+ *
+ * @param timeInMs - time in milliseconds
+ * @returns formatted date string
+ * @example formatDate(number) => Jan 11, 2025, 10:17:13 PM GMT+5:30
+ */
+export const formatDate = (timeInMs: number) => {
+  if (timeInMs === 0) return null;
+
+  return Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'long',
+  }).format(new Date(timeInMs));
 };

--- a/components/Profile/Staking/RecovererAlert.tsx
+++ b/components/Profile/Staking/RecovererAlert.tsx
@@ -1,10 +1,17 @@
 import { Alert, Flex, Typography } from 'antd';
 
+import { formatDate } from 'common-util/functions/time';
 import { GOVERN_APP_URL } from 'util/constants';
 
 const { Text, Paragraph } = Typography;
 
-export const RecovererAlert = ({ isNew }: { isNew: boolean }) => {
+export const RecovererAlert = ({
+  isNew,
+  unstakeTimestamp,
+}: {
+  isNew: boolean;
+  unstakeTimestamp: number | null;
+}) => {
   return (
     <Alert
       type="warning"
@@ -34,6 +41,16 @@ export const RecovererAlert = ({ isNew }: { isNew: boolean }) => {
               one way to do so in the PDF.
             </li>
           </ol>
+          {unstakeTimestamp && (
+            <Paragraph>
+              <span className="font-weight-600">Note:</span> if you have recently staked, you may
+              not be able to begin the withdrawal process yet, as you need to remain staked for a
+              certain period.
+              <br />
+              You can start withdrawing no earlier than:{' '}
+              <span className="font-weight-600">{formatDate(unstakeTimestamp * 1000)}</span>
+            </Paragraph>
+          )}
           <a
             href={`${GOVERN_APP_URL}/proposals?proposalId=36031414401270968281819940673886809451115732209347053152611693625665455429080`}
             target="_blank"

--- a/components/Profile/Staking/StakingDetails.tsx
+++ b/components/Profile/Staking/StakingDetails.tsx
@@ -104,9 +104,11 @@ const InfoColumn = ({
 
 export const StakingDetails = ({ profile }: { profile: XProfile }) => {
   const { address: account } = useAccount();
+  const isNewContracts = !!profile.service_id;
+
   const { data, isLoading: isServiceInfoLoading } = useServiceInfo({
     account,
-    isNew: !!profile.service_id,
+    isNew: isNewContracts,
   });
   const stakingInstance = data?.stakingInstance;
   const contractDetails = stakingInstance && STAKING_CONTRACTS_DETAILS[getAddress(stakingInstance)];
@@ -200,7 +202,7 @@ export const StakingDetails = ({ profile }: { profile: XProfile }) => {
             title={
               <Text>
                 You’ll be able to restake at approximately{' '}
-                {formatDynamicTimeRange(stakingDetails.evictionExpiresTimestamp)}.
+                {formatDynamicTimeRange(stakingDetails.canUnstakeTimestamp)}.
               </Text>
             }
             color={COLOR.WHITE}
@@ -218,7 +220,7 @@ export const StakingDetails = ({ profile }: { profile: XProfile }) => {
     isServiceInfoLoading,
     stakingDetails.stakingStatus,
     stakingDetails.isEligibleForStaking,
-    stakingDetails.evictionExpiresTimestamp,
+    stakingDetails.canUnstakeTimestamp,
     contractDetails,
     isRestaking,
     handleRestake,
@@ -226,7 +228,12 @@ export const StakingDetails = ({ profile }: { profile: XProfile }) => {
 
   return (
     <>
-      {profile.service_id_old && <RecovererAlert isNew={!!profile.service_id} />}
+      {profile.service_id_old && (
+        <RecovererAlert
+          isNew={isNewContracts}
+          unstakeTimestamp={isNewContracts ? null : stakingDetails.canUnstakeTimestamp}
+        />
+      )}
       <StyledDivider />
       <Title level={5}>Rewards</Title>
       <Row gutter={[16, 24]} className="w-100 mb-32">

--- a/components/Profile/Staking/index.tsx
+++ b/components/Profile/Staking/index.tsx
@@ -1,11 +1,13 @@
 import { Button, Card, Flex, Typography } from 'antd';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { XProfile } from 'types/x';
 
 import { StakingDetails } from './StakingDetails';
+import { useUpdateProfileIfOldServiceTerminated } from './hooks';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -31,8 +33,7 @@ const SetupStaking = () => (
 export const Staking = ({ profile }: { profile: XProfile }) => {
   const hasStaked = !!(profile.service_id_old || profile.service_id);
 
-  // TODO: check if service_id_old is terminated (meaning the user went through the recovery process)
-  // and clear service_id_old and service_multisig_old
+  useUpdateProfileIfOldServiceTerminated(profile);
 
   return (
     <Card bordered={false}>

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -38,40 +38,52 @@ export const OPERATE_APP_URL = 'https://operate.olas.network';
 
 export const STAKING_CONTRACTS_DETAILS: Record<
   string,
-  { name: string; totalBond: number; pointsPerEpoch: number; isDeprecated?: boolean }
+  {
+    name: string;
+    totalBond: number;
+    pointsPerEpoch: number;
+    maxSlots: number;
+    isDeprecated?: boolean;
+  }
 > = {
   '0x95146Adf659f455f300D7521B3b62A3b6c4aBA1F': {
     name: 'Contribute Alpha',
     totalBond: 100,
     pointsPerEpoch: 200,
+    maxSlots: 100,
     isDeprecated: true,
   },
   '0x2C8a5aC7B431ce04a037747519BA475884BCe2Fb': {
     name: 'Contribute Alpha 2',
     totalBond: 100,
     pointsPerEpoch: 200,
+    maxSlots: 100,
     isDeprecated: true,
   },
   '0x708E511d5fcB3bd5a5d42F42aA9a69EC5B0Ee2E8': {
     name: 'Contribute Alpha 3',
     totalBond: 500,
     pointsPerEpoch: 1000,
+    maxSlots: 100,
     isDeprecated: true,
   },
   '0xe2E68dDafbdC0Ae48E39cDd1E778298e9d865cF4': {
     name: 'Contribute Beta I',
     totalBond: 100,
     pointsPerEpoch: 200,
+    maxSlots: 10,
   },
   '0x6Ce93E724606c365Fc882D4D6dfb4A0a35fE2387': {
     name: 'Contribute Beta II',
     totalBond: 300,
     pointsPerEpoch: 600,
+    maxSlots: 10,
   },
   '0x28877FFc6583170a4C9eD0121fc3195d06fd3A26': {
     name: 'Contribute Beta III',
     totalBond: 500,
     pointsPerEpoch: 1000,
+    maxSlots: 10,
   },
 };
 

--- a/util/staking.ts
+++ b/util/staking.ts
@@ -170,13 +170,12 @@ export const useStakingDetails = (
     : SERVICE_STAKING_STATE[0];
 
   // Eviction expire timestamp
-  const evictionExpiresTimestamp =
-    Number(serviceInfo?.tsStart ?? 0) + Number(minStakingDuration ?? 0);
+  const canUnstakeTimestamp = Number(serviceInfo?.tsStart ?? 0) + Number(minStakingDuration ?? 0);
 
   const isServiceStakedForMinimumDuration =
     !isNil(serviceInfo?.tsStart) &&
     !isNil(minStakingDuration) &&
-    evictionExpiresTimestamp <= Math.round(Date.now() / 1000);
+    canUnstakeTimestamp <= Math.round(Date.now() / 1000);
 
   // TODO: add check if the contract has enough rewards and slots
   const isEligibleForStaking =
@@ -191,7 +190,7 @@ export const useStakingDetails = (
       epochLength: livenessPeriod ? formatTimeDifference(Number(livenessPeriod) * 1000) : null,
       stakingStatus,
       isEligibleForStaking,
-      evictionExpiresTimestamp,
+      canUnstakeTimestamp,
       tsStart: serviceInfo?.tsStart,
     },
     isLoading:


### PR DESCRIPTION
1) Displays the time when a user can start recovering process (we have many tickets from recently restaked users who can't figure out why unstaking fails)
2) Clear old data if service is terminated, so that users don't see the alert
3) Increase gas limit (advised by Aleks, will handle better next time), currently create&stake fails due to out of gas issue
4) check available slots to not allow selecting fully taken contracts

<img width="690" alt="Screenshot 2025-02-12 at 11 55 15" src="https://github.com/user-attachments/assets/3db2d7e9-36bb-4e24-96cc-dfdef070746d" />

<img width="678" alt="Screenshot 2025-02-12 at 11 57 04" src="https://github.com/user-attachments/assets/97718d47-c10c-438e-bd7f-86f995f07686" />
